### PR TITLE
Fix for encoded video.

### DIFF
--- a/album.py
+++ b/album.py
@@ -66,18 +66,19 @@ def album(id):
                 i.fileModifiedAt
             ).strftime("%Y-%m-%dT%H:%M:%S%z")
 
-    items = [
-        (
-            f"{RAW_SERVER_URL}/api/assets/{asset.id}/original|x-api-key={API_KEY}",
-            xbmcgui.ListItem(get_asset_name(asset)),
-            False,
-        )
-        for asset in res
-    ]
+    items = []
+    for asset in res:
+        if asset.type == "IMAGE":
+            url = f"{RAW_SERVER_URL}/api/assets/{asset.id}/original|x-api-key={API_KEY}"
+        else:
+            url = f"{RAW_SERVER_URL}/api/assets/{asset.id}/video/playback|x-api-key={API_KEY}"
+        items.append((url, xbmcgui.ListItem(get_asset_name(asset)), False))
+
     for item, asset in zip(items, res):
         item[1].setArt({"thumb": getThumbUrl(asset.id)})
         item[1].setProperty("MimeType", asset.originalMimeType)
         item[1].setDateTime(asset.exifInfo.dateTimeOriginal)
+
     xbmcplugin.addDirectoryItems(HANDLE, items, len(items))
     xbmcplugin.addSortMethod(HANDLE, sortMethod=xbmcplugin.SORT_METHOD_DATE)
     xbmcplugin.endOfDirectory(HANDLE, cacheToDisc=False)


### PR DESCRIPTION
Previously all assets in an album used the /original endpoint, causing Kodi to ignore Immich transcoded versions. Now asset type is checked: images use /original, videos use /video/playback. This can also solve [issue #34](https://github.com/vladd11/immich-kodi/issues/34) provided that the video is re-encoded in Immich with autorotate.